### PR TITLE
7 feat 챌린지 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Application.yml ###
+/src/main/resources/application-dev.yml

--- a/src/main/java/com/alom/dorundorunbe/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/challenge/controller/ChallengeController.java
@@ -1,0 +1,55 @@
+package com.alom.dorundorunbe.domain.challenge.controller;
+
+import com.alom.dorundorunbe.domain.challenge.dto.ChallengeRequestDto;
+import com.alom.dorundorunbe.domain.challenge.dto.ChallengeResponseDto;
+import com.alom.dorundorunbe.domain.challenge.service.ChallengeService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/challenges")
+@Tag(
+    name = "챌런지 관리 API"
+)
+public class ChallengeController implements ChallengeControllerDocs {
+
+  private final ChallengeService challengeService;
+
+  @PostMapping
+  public ResponseEntity<ChallengeResponseDto> createChallenge(@RequestBody ChallengeRequestDto requestDto) {
+    ChallengeResponseDto responseDto = challengeService.createChallenge(requestDto);
+    return ResponseEntity.ok(responseDto);
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<ChallengeResponseDto> updateChallenge(@PathVariable Long id, @RequestBody ChallengeRequestDto requestDto) {
+    ChallengeResponseDto responseDto = challengeService.updateChallenge(id, requestDto);
+    return ResponseEntity.ok(responseDto);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteChallenge(@PathVariable Long id) {
+    challengeService.deleteChallenge(id);
+    return ResponseEntity.noContent().build();
+  }
+
+
+  @GetMapping("/{id}")
+  public ResponseEntity<ChallengeResponseDto> getChallengeDetail(@PathVariable Long id) {
+    ChallengeResponseDto responseDto = challengeService.getChallengeDetail(id);
+
+    return ResponseEntity.ok(responseDto);
+  }
+
+  @GetMapping
+  public ResponseEntity<List<ChallengeResponseDto>> getAllChallenges() {
+    List<ChallengeResponseDto> responseDtos = challengeService.getAllChallenges();
+    return ResponseEntity.ok(responseDtos);
+  }
+
+}

--- a/src/main/java/com/alom/dorundorunbe/domain/challenge/controller/ChallengeControllerDocs.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/challenge/controller/ChallengeControllerDocs.java
@@ -1,0 +1,105 @@
+package com.alom.dorundorunbe.domain.challenge.controller;
+
+import com.alom.dorundorunbe.domain.challenge.dto.ChallengeRequestDto;
+import com.alom.dorundorunbe.domain.challenge.dto.ChallengeResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+public interface ChallengeControllerDocs {
+
+  @Operation(
+      summary = "챌린지 생성",
+      description = """
+            **챌린지 생성**
+
+            새로운 챌린지를 생성합니다.
+
+            **입력 파라미터:**
+                    
+            - **`String name`**: 챌린지 이름
+            - **`String description`**: 챌린지 설명
+            - **`LocalDate startDate`**: 챌린지 시작 날짜
+            - **`LocalDate endDate`**: 챌린지 종료 날짜
+            - **`String location`**: 챌린지 위치
+            - **`int distance`**: 챌린지 거리 (km)
+
+            **반환값:**
+            
+            - **`ChallengeResponseDto`**: 생성된 챌린지 정보
+        """
+  )
+  ResponseEntity<ChallengeResponseDto> createChallenge(@RequestBody ChallengeRequestDto requestDto);
+
+  @Operation(
+      summary = "챌린지 수정",
+      description = """
+            **챌린지 수정**
+
+            기존의 챌린지 정보를 수정합니다.
+
+            **입력 파라미터:**
+                    
+            - **`Long id`**: 수정할 챌린지의 ID
+            - **`ChallengeRequestDto`**: 수정할 챌린지의 새로운 정보
+
+            **반환값:**
+            
+            - **`ChallengeResponseDto`**: 수정된 챌린지 정보
+        """
+  )
+  ResponseEntity<ChallengeResponseDto> updateChallenge(@PathVariable Long id, @RequestBody ChallengeRequestDto requestDto);
+
+  @Operation(
+      summary = "챌린지 삭제",
+      description = """
+            **챌린지 삭제**
+
+            지정된 ID의 챌린지를 삭제합니다.
+
+            **입력 파라미터:**
+                    
+            - **`Long id`**: 삭제할 챌린지의 ID
+
+            **반환값:**
+            
+            - **`void`**: 삭제 완료 시 반환값 없음
+        """
+  )
+  ResponseEntity<Void> deleteChallenge(@PathVariable Long id);
+
+  @Operation(
+      summary = "챌린지 상세 조회",
+      description = """
+            **챌린지 상세 조회**
+
+            특정 ID를 가진 챌린지의 상세 정보를 조회합니다.
+
+            **입력 파라미터:**
+                    
+            - **`Long id`**: 조회할 챌린지의 ID
+
+            **반환값:**
+            
+            - **`ChallengeResponseDto`**: 조회된 챌린지의 상세 정보
+        """
+  )
+  ResponseEntity<ChallengeResponseDto> getChallengeDetail(@PathVariable Long id);
+
+  @Operation(
+      summary = "챌린지 목록 조회",
+      description = """
+            **챌린지 목록 조회**
+
+            등록된 모든 챌린지의 목록을 조회합니다.
+
+            **반환값:**
+            
+            - **`List<ChallengeResponseDto>`**: 등록된 챌린지의 목록
+        """
+  )
+  ResponseEntity<List<ChallengeResponseDto>> getAllChallenges();
+}

--- a/src/main/java/com/alom/dorundorunbe/domain/challenge/controller/UserChallengeController.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/challenge/controller/UserChallengeController.java
@@ -1,0 +1,46 @@
+package com.alom.dorundorunbe.domain.challenge.controller;
+
+import com.alom.dorundorunbe.domain.challenge.dto.ChallengeResponseDto;
+import com.alom.dorundorunbe.domain.challenge.service.UserChallengeService;
+import com.alom.dorundorunbe.domain.user.domain.User;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/challenges")
+@RequiredArgsConstructor
+@Tag(
+    name = "챌런지 유저관리 API"
+)
+public class UserChallengeController implements UserChallengeControllerDocs{
+
+  private final UserChallengeService userChallengeService;
+
+  @PostMapping("/{challengeId}/join")
+  public ResponseEntity<String> joinChallenge(@PathVariable Long challengeId, @RequestParam Long userId) {
+    userChallengeService.joinChallenge(userId, challengeId);
+    return ResponseEntity.ok("User joined the challenge successfully");
+  }
+
+  @DeleteMapping("/{challengeId}/leave")
+  public ResponseEntity<String> leaveChallenge(@PathVariable Long challengeId, @RequestParam Long userId) {
+    userChallengeService.leaveChallenge(userId, challengeId);
+    return ResponseEntity.ok("User left the challenge successfully");
+  }
+
+  @GetMapping("/{challengeId}/participants")
+  public ResponseEntity<List<User>> getChallengeParticipants(@PathVariable Long challengeId) {
+    List<User> participants = userChallengeService.getChallengeParticipants(challengeId);
+    return ResponseEntity.ok(participants);
+  }
+
+  @GetMapping("/users/{userId}/challenges")
+  public ResponseEntity<List<ChallengeResponseDto>> getUserChallenges(@PathVariable Long userId) {
+    List<ChallengeResponseDto> userChallenges = userChallengeService.getUserChallenges(userId);
+    return ResponseEntity.ok(userChallenges);
+  }
+}

--- a/src/main/java/com/alom/dorundorunbe/domain/challenge/controller/UserChallengeControllerDocs.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/challenge/controller/UserChallengeControllerDocs.java
@@ -1,0 +1,97 @@
+package com.alom.dorundorunbe.domain.challenge.controller;
+
+import com.alom.dorundorunbe.domain.challenge.dto.ChallengeResponseDto;
+import com.alom.dorundorunbe.domain.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+public interface UserChallengeControllerDocs {
+
+  @Operation(
+      summary = "챌린지 참가",
+      description = """
+            **챌린지 참가 API**
+            
+            유저가 특정 챌린지에 참가합니다.
+            
+            **요청 파라미터:**
+            
+            - **`challengeId (Path Variable)`**: 참가할 챌린지의 ID
+            - **`userId (Request Param)`**: 참가하는 유저의 ID
+            
+            **응답 값:**
+            
+            - **`String`**: 참가 완료 메시지
+        """
+  )
+  ResponseEntity<String> joinChallenge(
+      @PathVariable Long challengeId,
+      @RequestParam Long userId
+  );
+
+  @Operation(
+      summary = "챌린지 탈퇴",
+      description = """
+            **챌린지 탈퇴 API**
+            
+            유저가 특정 챌린지에서 탈퇴합니다.
+            
+            **요청 파라미터:**
+            
+            - **`challengeId (Path Variable)`**: 탈퇴할 챌린지의 ID
+            - **`userId (Request Param)`**: 탈퇴하는 유저의 ID
+            
+            **응답 값:**
+            
+            - **`String`**: 탈퇴 완료 메시지
+        """
+  )
+  ResponseEntity<String> leaveChallenge(
+      @PathVariable Long challengeId,
+      @RequestParam Long userId
+  );
+
+  @Operation(
+      summary = "챌린지 참가자 목록 조회",
+      description = """
+            **챌린지 참가자 목록 조회 API**
+            
+            특정 챌린지에 참가한 유저들의 목록을 조회합니다.
+            
+            **요청 파라미터:**
+            
+            - **`challengeId (Path Variable)`**: 조회할 챌린지의 ID
+            
+            **응답 값:**
+            
+            - **`List<User>`**: 참가 유저 목록
+        """
+  )
+  ResponseEntity<List<User>> getChallengeParticipants(
+      @PathVariable Long challengeId
+  );
+
+  @Operation(
+      summary = "유저가 참가한 챌린지 목록 조회",
+      description = """
+            **유저가 참가한 챌린지 목록 조회 API**
+            
+            특정 유저가 참가한 모든 챌린지 목록을 조회합니다.
+            
+            **요청 파라미터:**
+            
+            - **`userId (Path Variable)`**: 조회할 유저의 ID
+            
+            **응답 값:**
+            
+            - **`List<ChallengeResponseDto>`**: 참가한 챌린지 목록
+        """
+  )
+  ResponseEntity<List<ChallengeResponseDto>> getUserChallenges(
+      @PathVariable Long userId
+  );
+}

--- a/src/main/java/com/alom/dorundorunbe/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/challenge/domain/Challenge.java
@@ -1,5 +1,6 @@
 package com.alom.dorundorunbe.domain.challenge.domain;
 
+import com.alom.dorundorunbe.domain.challenge.dto.ChallengeResponseDto;
 import com.alom.dorundorunbe.global.util.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -7,9 +8,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
-@Entity @Getter
+@Entity
+@Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
@@ -24,14 +26,41 @@ public class Challenge extends BaseEntity {
 
     private String description;
 
-    @Column(nullable = false)
-    private LocalDateTime startDate;
+    private String challengeUrl;
 
     @Column(nullable = false)
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+
+    @Column(nullable = false)
+    private LocalDate endDate;
 
     private String location;
 
     @Column(nullable = false)
-    private long distance;
+    private int distance;
+
+    public void update(String name, String description, String challengeUrl, LocalDate startDate, LocalDate endDate, String location, int distance) {
+        this.name = name;
+        this.description = description;
+        this.challengeUrl = challengeUrl;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.location = location;
+        this.distance = distance;
+    }
+
+    public ChallengeResponseDto toResponseDto() {
+        return new ChallengeResponseDto(
+            this.id,
+            this.name,
+            this.description,
+            this.challengeUrl,
+            this.startDate,
+            this.endDate,
+            this.location,
+            this.distance
+        );
+    }
+
+
 }

--- a/src/main/java/com/alom/dorundorunbe/domain/challenge/dto/ChallengeRequestDto.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/challenge/dto/ChallengeRequestDto.java
@@ -1,0 +1,14 @@
+package com.alom.dorundorunbe.domain.challenge.dto;
+
+import java.time.LocalDate;
+
+public record ChallengeRequestDto(
+    String name,
+    String description,
+    String challengeUrl,
+    LocalDate startDate,
+    LocalDate endDate,
+    String location,
+    int distance
+) {
+}

--- a/src/main/java/com/alom/dorundorunbe/domain/challenge/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/challenge/dto/ChallengeResponseDto.java
@@ -1,0 +1,14 @@
+package com.alom.dorundorunbe.domain.challenge.dto;
+
+import java.time.LocalDate;
+
+public record ChallengeResponseDto(
+    Long id,
+    String name,
+    String description,
+    String challengeUrl,
+    LocalDate startDate,
+    LocalDate endDate,
+    String location,
+    int distance
+) {}

--- a/src/main/java/com/alom/dorundorunbe/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/challenge/repository/ChallengeRepository.java
@@ -1,0 +1,7 @@
+package com.alom.dorundorunbe.domain.challenge.repository;
+
+import com.alom.dorundorunbe.domain.challenge.domain.Challenge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+}

--- a/src/main/java/com/alom/dorundorunbe/domain/challenge/repository/UserChallengeRepository.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/challenge/repository/UserChallengeRepository.java
@@ -1,0 +1,15 @@
+package com.alom.dorundorunbe.domain.challenge.repository;
+
+import com.alom.dorundorunbe.domain.challenge.domain.UserChallenge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserChallengeRepository extends JpaRepository<UserChallenge, Long> {
+  Optional<UserChallenge> findByUserIdAndChallengeId(Long userId, Long challengeId);
+
+  List<UserChallenge> findByChallengeId(Long challengeId);
+
+  List<UserChallenge> findByUserId(Long userId);
+}

--- a/src/main/java/com/alom/dorundorunbe/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/challenge/service/ChallengeService.java
@@ -1,0 +1,74 @@
+package com.alom.dorundorunbe.domain.challenge.service;
+
+
+import com.alom.dorundorunbe.domain.challenge.domain.Challenge;
+import com.alom.dorundorunbe.domain.challenge.dto.ChallengeRequestDto;
+import com.alom.dorundorunbe.domain.challenge.dto.ChallengeResponseDto;
+import com.alom.dorundorunbe.domain.challenge.repository.ChallengeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeService {
+
+  private final ChallengeRepository challengeRepository;
+
+  public ChallengeResponseDto createChallenge(ChallengeRequestDto requestDto) {
+    Challenge challenge = Challenge.builder()
+        .name(requestDto.name())
+        .description(requestDto.description())
+        .challengeUrl(requestDto.challengeUrl())
+        .startDate(requestDto.startDate())
+        .endDate(requestDto.endDate())
+        .location(requestDto.location())
+        .distance(requestDto.distance())
+        .build();
+
+    Challenge savedChallenge = challengeRepository.save(challenge);
+    return savedChallenge.toResponseDto();
+  }
+
+  public ChallengeResponseDto updateChallenge(Long id, ChallengeRequestDto requestDto) {
+    Challenge challenge = challengeRepository.findById(id)
+        .orElseThrow(() -> new NoSuchElementException("Challenge not found with id: " + id));
+
+    challenge.update(
+        requestDto.name(),
+        requestDto.description(),
+        requestDto.challengeUrl(),
+        requestDto.startDate(),
+        requestDto.endDate(),
+        requestDto.location(),
+        requestDto.distance()
+    );
+
+    Challenge updatedChallenge = challengeRepository.save(challenge);
+    return updatedChallenge.toResponseDto();
+  }
+
+  public void deleteChallenge(Long id) {
+    Challenge challenge = challengeRepository.findById(id)
+        .orElseThrow(() -> new NoSuchElementException("Challenge not found with id: " + id));
+
+    challengeRepository.delete(challenge);
+  }
+
+  public ChallengeResponseDto getChallengeDetail(Long id) {
+    Challenge challenge = challengeRepository.findById(id)
+        .orElseThrow(() -> new NoSuchElementException("Challenge not found with id: " + id));
+    return challenge.toResponseDto();
+  }
+
+  public List<ChallengeResponseDto> getAllChallenges() {
+    List<Challenge> challenges = challengeRepository.findAll();
+    return challenges.stream()
+        .map(Challenge::toResponseDto)
+        .collect(Collectors.toList());
+  }
+
+}

--- a/src/main/java/com/alom/dorundorunbe/domain/challenge/service/UserChallengeService.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/challenge/service/UserChallengeService.java
@@ -1,0 +1,61 @@
+package com.alom.dorundorunbe.domain.challenge.service;
+
+import com.alom.dorundorunbe.domain.challenge.domain.Challenge;
+import com.alom.dorundorunbe.domain.challenge.domain.UserChallenge;
+import com.alom.dorundorunbe.domain.challenge.dto.ChallengeResponseDto;
+import com.alom.dorundorunbe.domain.challenge.repository.ChallengeRepository;
+import com.alom.dorundorunbe.domain.challenge.repository.UserChallengeRepository;
+import com.alom.dorundorunbe.domain.user.domain.User;
+import com.alom.dorundorunbe.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserChallengeService {
+
+  private final UserChallengeRepository userChallengeRepository;
+  private final UserRepository userRepository;
+  private final ChallengeRepository challengeRepository;
+
+  public void joinChallenge(Long userId, Long challengeId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new NoSuchElementException("User not found with id: " + userId));
+    Challenge challenge = challengeRepository.findById(challengeId)
+        .orElseThrow(() -> new NoSuchElementException("Challenge not found with id: " + challengeId));
+
+    UserChallenge userChallenge = UserChallenge.builder()
+        .user(user)
+        .challenge(challenge)
+        .build();
+
+    userChallengeRepository.save(userChallenge);
+  }
+
+  public void leaveChallenge(Long userId, Long challengeId) {
+    UserChallenge userChallenge = userChallengeRepository.findByUserIdAndChallengeId(userId, challengeId)
+        .orElseThrow(() -> new NoSuchElementException("UserChallenge not found for userId: " + userId + " and challengeId: " + challengeId));
+
+    userChallengeRepository.delete(userChallenge);
+  }
+
+  public List<User> getChallengeParticipants(Long challengeId) {
+    List<UserChallenge> userChallenges = userChallengeRepository.findByChallengeId(challengeId);
+
+    return userChallenges.stream()
+        .map(UserChallenge::getUser)
+        .collect(Collectors.toList());
+  }
+
+  public List<ChallengeResponseDto> getUserChallenges(Long userId) {
+    List<UserChallenge> userChallenges = userChallengeRepository.findByUserId(userId);
+
+    return userChallenges.stream()
+        .map(userChallenge -> userChallenge.getChallenge().toResponseDto())
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/alom/dorundorunbe/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.alom.dorundorunbe.domain.user.repository;
+
+import com.alom.dorundorunbe.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}


### PR DESCRIPTION
## ❓ 기능 추가 배경

여러 단체에서 개최하는 달리기 행사들을 관리하기 위한 기능이 필요함

## ➕ 추가/변경된 기능

챌린지 CRUD와 유저의 참가, 탈퇴 등 구현

"""관리자만 접근할수 있는 api들이 있어서 로그인 완성되고 수정 필요"""

## 🗎 관련 이슈

#7 
