### PR TITLE
35 test 랭킹 테스트 구현

### DIFF
--- a/src/main/java/com/alom/dorundorunbe/domain/ranking/domain/Ranking.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/ranking/domain/Ranking.java
@@ -1,6 +1,5 @@
 package com.alom.dorundorunbe.domain.ranking.domain;
 
-import com.alom.dorundorunbe.domain.user.domain.User;
 
 import com.alom.dorundorunbe.global.enums.Tier;
 import com.alom.dorundorunbe.global.util.BaseEntity;

--- a/src/main/java/com/alom/dorundorunbe/domain/ranking/domain/UserRanking.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/ranking/domain/UserRanking.java
@@ -39,7 +39,7 @@ public class UserRanking extends BaseEntity {
     @Builder.Default
     private List<RankingPoint> points = new ArrayList<>();
 
-    public static UserRanking create(User user, Ranking ranking) {
+    public static UserRanking create(User user) {
 
         return UserRanking.builder()
                 .user(user)
@@ -62,11 +62,12 @@ public class UserRanking extends BaseEntity {
 
 
     }
-    public void updateAveragePoint() {
+    public Double updateAveragePoint() {
         this.averagePoint = points.stream()
                 .mapToDouble(RankingPoint::getPoint)
                 .average()
                 .orElse(0.0);
+        return averagePoint;
     }
 
     public void updateGrade(Long grade){

--- a/src/main/java/com/alom/dorundorunbe/domain/ranking/dto/UserRankingDto.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/ranking/dto/UserRankingDto.java
@@ -39,7 +39,7 @@ public class UserRankingDto {
                 .points(userRanking.getPoints().stream()
                         .map(RankingPoint::getPoint)
                         .toList())
-                .createdAt(userRanking.getCreatedAt().toString())
+                .createdAt(userRanking.getCreatedAt() != null ? userRanking.getCreatedAt().toString() : "N/A")
                 .userInfoDto(UserInfoDto.of(userRanking.getUser()))
                 .build();
     }

--- a/src/main/java/com/alom/dorundorunbe/domain/ranking/repository/UserRankingRepository.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/ranking/repository/UserRankingRepository.java
@@ -15,9 +15,7 @@ import java.util.Optional;
 public interface UserRankingRepository extends JpaRepository<UserRanking, Long> {
 
 
-    boolean existsByUserAndRanking(User user, Ranking ranking);
 
-    boolean existsByUser(User user);
 
     Optional<UserRanking> findByUserId(Long userId);
 

--- a/src/main/java/com/alom/dorundorunbe/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/ranking/service/RankingService.java
@@ -52,7 +52,7 @@ public class RankingService { //랭킹 참가, 랭킹 스케줄 로직
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
-        if (userRankingRepository.existsByUser(user)) {
+        if (user.isRankingParticipated()) {
             throw new BusinessException(ErrorCode.RANKING_ALREADY_PARTICIPATED);
         }
 
@@ -67,9 +67,7 @@ public class RankingService { //랭킹 참가, 랭킹 스케줄 로직
 
     }
 
-    /**
-     * ✅ 배치고사 진행 여부 확인 및 처리
-     */
+
     private void checkPlacementTest(User user) {
 
 
@@ -102,9 +100,7 @@ public class RankingService { //랭킹 참가, 랭킹 스케줄 로직
         user.setTier(assignedTier);
     }
 
-    /**
-     * ✅ 랭킹 참가 처리
-     */
+
     private void joinRanking(User user) {
         Ranking ranking = rankingRepository.findByTier(user.getTier())
                 .orElseThrow(() -> new BusinessException(ErrorCode.RANKING_NOT_FOUND));

--- a/src/main/java/com/alom/dorundorunbe/domain/ranking/service/UserRankingService.java
+++ b/src/main/java/com/alom/dorundorunbe/domain/ranking/service/UserRankingService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -26,15 +27,16 @@ public class UserRankingService {
     @Transactional
     public void createUserRanking(User user, Ranking ranking) {
 
-        boolean alreadyParticipated = userRankingRepository.existsByUserAndRanking(user, ranking);
-        if (alreadyParticipated) {
+        if (user.isRankingParticipated()) {
             throw new BusinessException(ErrorCode.USER_ALREADY_IN_RANKING);
         }
 
 
-        UserRanking userRanking = UserRanking.create(user, ranking);
+
+        UserRanking userRanking = UserRanking.create(user);
         userRanking.confirmRanking(ranking);
         userRankingRepository.save(userRanking);
+        user.setRankingParticipated();
 
 
     }
@@ -54,10 +56,16 @@ public class UserRankingService {
         UserRanking userRanking = userRankingRepository.findByUserId(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.RANKING_NOT_FOUND));
 
-        // 추가 포인트 등록
         userRanking.addPoint(point);
-        if(userRanking.getPoints().size()>=3){
-            userRanking.updateAveragePoint();
+        if(userRanking.getPoints().size() < 3){
+            return;
+        }
+
+        Double averagePoint = userRanking.getAveragePoint();
+        Double newAvgPoint = userRanking.updateAveragePoint();
+
+        if (Objects.equals(averagePoint, newAvgPoint)) {
+            return;
         }
         Long rankingId = userRanking.getRanking().getId();
 
@@ -78,19 +86,20 @@ public class UserRankingService {
                 .sorted(Comparator.comparingDouble(UserRanking::getAveragePoint).reversed())
                 .toList();
 
-        double previousPoint = -1;
+        Double previousPoint = null;
         long rank = 0;
 
         for (int i = 0; i < validParticipants.size(); i++) {
             UserRanking userRanking = validParticipants.get(i);
 
-            if (i == 0 || !userRanking.getAveragePoint().equals(previousPoint)) {
+            if (i == 0 || !Objects.equals(userRanking.getAveragePoint(), previousPoint)) {
                 rank = i + 1;
             }
 
-            if (!userRanking.getGrade().equals(rank)) {
+            if (userRanking.getGrade() == null || !userRanking.getGrade().equals(rank)) {
                 userRanking.updateGrade(rank);
             }
+
             previousPoint = userRanking.getAveragePoint();
         }
     }

--- a/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingRewardServiceTest.java
+++ b/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingRewardServiceTest.java
@@ -1,0 +1,92 @@
+package com.alom.dorundorunbe.domain.ranking.service;
+
+import com.alom.dorundorunbe.domain.ranking.domain.Ranking;
+import com.alom.dorundorunbe.domain.ranking.domain.UserRanking;
+import com.alom.dorundorunbe.domain.ranking.repository.RankingRepository;
+import com.alom.dorundorunbe.domain.ranking.repository.UserRankingRepository;
+import com.alom.dorundorunbe.domain.user.domain.User;
+import com.alom.dorundorunbe.global.enums.Tier;
+import com.alom.dorundorunbe.global.util.point.service.PointService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RankingRewardServiceTest {
+
+    @InjectMocks
+    private RankingRewardService rankingRewardService;
+
+    @Mock
+    private RankingRepository rankingRepository;
+
+    @Mock
+    private UserRankingRepository userRankingRepository;
+
+    @Mock
+    private PointService pointService;
+
+    private Ranking ranking1, ranking2;
+    private User user1, user2, user3, user4;
+    private UserRanking userRanking1, userRanking2, userRanking3, userRanking4;
+    private final Long rankingId1 = 1L;
+    private final Long rankingId2 = 2L;
+
+    @BeforeEach
+    void setUp() {
+
+        ranking1 = Ranking.builder().id(rankingId1).tier(Tier.BEGINNER).build();
+        ranking2 = Ranking.builder().id(rankingId2).tier(Tier.AMATEUR).build();
+
+
+        user1 = createUser(1L, "User1", Tier.BEGINNER);
+        user2 = createUser(2L, "User2", Tier.BEGINNER);
+        user3 = createUser(3L, "User3", Tier.AMATEUR);
+        user4 = createUser(4L, "User4", Tier.AMATEUR);
+
+
+        userRanking1 = createUserRanking(1L, user1, ranking1, 1L);
+        userRanking2 = createUserRanking(2L, user2, ranking1, 2L);
+        userRanking3 = createUserRanking(3L, user3, ranking2, 1L);
+        userRanking4 = createUserRanking(4L, user4, ranking2, 2L);
+
+        lenient().when(rankingRepository.findAll()).thenReturn(List.of(ranking1, ranking2));
+
+        lenient().when(rankingRepository.existsById(rankingId1)).thenReturn(true);
+        lenient().when(rankingRepository.existsById(rankingId2)).thenReturn(true);
+        lenient().when(userRankingRepository.findWithUserByRankingId(rankingId1)).thenReturn(List.of(userRanking1, userRanking2));
+        lenient().when(userRankingRepository.findWithUserByRankingId(rankingId2)).thenReturn(List.of(userRanking3, userRanking4));
+    }
+
+    private User createUser(Long id, String nickname, Tier tier) {
+        return User.builder()
+                .id(id)
+                .nickname(nickname)
+                .tier(tier)
+                .cash(0L)
+                .lp(0.0)
+                .isRankingParticipated(true)
+                .build();
+    }
+
+    private UserRanking createUserRanking(Long id, User user, Ranking ranking, Long grade) {
+        UserRanking build = UserRanking.builder()
+                .id(id)
+                .user(user)
+                .grade(grade)
+                .build();
+        build.confirmRanking(ranking);
+        return build;
+
+    }
+}

--- a/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingRewardServiceTest.java
+++ b/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingRewardServiceTest.java
@@ -89,4 +89,10 @@ class RankingRewardServiceTest {
         return build;
 
     }
+    @Test
+    @DisplayName("랭킹 참가자 리스트에 정상적으로 추가되는지 검증")
+    void testParticipantsAreAddedToRanking() {
+        assertThat(ranking1.getParticipants()).containsExactlyInAnyOrder(userRanking1, userRanking2);
+        assertThat(ranking2.getParticipants()).containsExactlyInAnyOrder(userRanking3, userRanking4);
+    }
 }

--- a/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingRewardServiceTest.java
+++ b/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingRewardServiceTest.java
@@ -95,4 +95,37 @@ class RankingRewardServiceTest {
         assertThat(ranking1.getParticipants()).containsExactlyInAnyOrder(userRanking1, userRanking2);
         assertThat(ranking2.getParticipants()).containsExactlyInAnyOrder(userRanking3, userRanking4);
     }
+
+    @Test
+    @DisplayName("주간 보상 지급 후 랭킹 참가자 삭제 및 참여 상태 초기화 검증")
+    void testProcessWeeklyRewards() {
+
+        doAnswer(invocation -> {
+            Long rankingId = invocation.getArgument(0);
+            List<UserRanking> rankings = userRankingRepository.findWithUserByRankingId(rankingId);
+
+            for (UserRanking userRanking : rankings) {
+                userRanking.getUser().resetRankingParticipated();
+            }
+            return null;
+        }).when(pointService).giveRankingRewardToUsersByRanking(anyLong());
+
+
+        rankingRewardService.processWeeklyRewards();
+
+
+        verify(pointService, times(1)).giveRankingRewardToUsersByRanking(rankingId1);
+        verify(pointService, times(1)).giveRankingRewardToUsersByRanking(rankingId2);
+
+
+        verify(userRankingRepository, times(1)).deleteByRankingId(rankingId1);
+        verify(userRankingRepository, times(1)).deleteByRankingId(rankingId2);
+
+
+        assertThat(user1.isRankingParticipated()).isFalse();
+        assertThat(user2.isRankingParticipated()).isFalse();
+        assertThat(user3.isRankingParticipated()).isFalse();
+        assertThat(user4.isRankingParticipated()).isFalse();
+
+    }
 }

--- a/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingServiceTest.java
+++ b/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingServiceTest.java
@@ -75,4 +75,18 @@ class RankingServiceTest {
                 .endTime(LocalDateTime.now().minusMinutes(5))
                 .build();
     }
+
+    @Test
+    @DisplayName("랭킹 참가 시 배치고사가 필요한 경우, 랭킹 참여 날짜가 설정된다")
+    void handleRankingParticipation_ShouldStartPlacementTest_IfRankingParticipationDateIsNull() {
+        // Given
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        // When
+        rankingService.handleRankingParticipation(1L);
+
+        // Then
+        assertThat(user.getRankingParticipationDate()).isNotNull(); // 배치고사 시작되었는지 확인
+        verify(userRepository, times(1)).findById(1L); // 사용자 조회 실행 검증
+    }
 }

--- a/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingServiceTest.java
+++ b/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingServiceTest.java
@@ -168,4 +168,42 @@ class RankingServiceTest {
         verify(rankingRepository, times(1)).findByTier(user.getTier());
         verify(userRankingService, times(1)).createUserRanking(user, ranking);
     }
+
+    @Test
+    @DisplayName("handleRankingParticipation : 평균 시간이 1200초 미만이어도 AMATEUR 티어에 배정되는지 확인(배치고사 특성 상 아무리 잘 뛰어도 최대 아마추어)")
+    void handleRankingParticipation_thresholdTest_assignsAmateur() {
+
+        user.setRankingParticipationDate(LocalDateTime.now().minusDays(3));
+
+
+        List<RunningRecord> records = List.of(
+                mockRunningRecord(1100),
+                mockRunningRecord(1150),
+                mockRunningRecord(1200)
+        );
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(runningRecordRepository.countByUserAndDistanceAndCreatedAtAfter(eq(user), eq(5.0), eq(user.getRankingParticipationDate())))
+                .thenReturn(3L);
+        when(runningRecordRepository.findTop3FastestRecordsAfterParticipation(eq(user), eq(5.0), eq(user.getRankingParticipationDate()), any()))
+                .thenReturn(records);
+        when(rankingRepository.findByTier(any(Tier.class))).thenReturn(Optional.of(ranking));
+
+        doAnswer(invocation -> {
+            User mockedUser = invocation.getArgument(0);
+            mockedUser.setRankingParticipated();
+            return null;
+        }).when(userRankingService).createUserRanking(any(User.class), any(Ranking.class));
+
+
+        rankingService.handleRankingParticipation(1L);
+
+
+        assertThat(user.getTier()).isNotNull();
+        assertThat(user.getTier()).isEqualTo(Tier.determineTier(1500));
+        assertThat(user.isRankingParticipated()).isTrue();
+
+        verify(rankingRepository, times(1)).findByTier(user.getTier());
+        verify(userRankingService, times(1)).createUserRanking(user, ranking);
+    }
 }

--- a/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingServiceTest.java
+++ b/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingServiceTest.java
@@ -66,4 +66,13 @@ class RankingServiceTest {
                 .tier(Tier.AMATEUR)
                 .build();
     }
+    private RunningRecord mockRunningRecord(int elapsedTime) {
+        return RunningRecord.builder()
+                .user(user)
+                .distance(5.0)
+                .elapsedTime(elapsedTime)
+                .startTime(LocalDateTime.now().minusMinutes(30))
+                .endTime(LocalDateTime.now().minusMinutes(5))
+                .build();
+    }
 }

--- a/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingServiceTest.java
+++ b/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingServiceTest.java
@@ -1,0 +1,69 @@
+package com.alom.dorundorunbe.domain.ranking.service;
+
+import com.alom.dorundorunbe.domain.ranking.domain.Ranking;
+import com.alom.dorundorunbe.domain.ranking.repository.RankingRepository;
+
+import com.alom.dorundorunbe.domain.runningrecord.domain.RunningRecord;
+import com.alom.dorundorunbe.domain.runningrecord.repository.RunningRecordRepository;
+import com.alom.dorundorunbe.domain.user.domain.User;
+import com.alom.dorundorunbe.domain.user.repository.UserRepository;
+import com.alom.dorundorunbe.global.enums.Tier;
+import com.alom.dorundorunbe.global.exception.BusinessException;
+import com.alom.dorundorunbe.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RankingServiceTest {
+    @Mock
+    private RankingRepository rankingRepository;
+
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RunningRecordRepository runningRecordRepository;
+
+    @Mock
+    private UserRankingService userRankingService;
+
+    @InjectMocks
+    private RankingService rankingService;
+
+    private User user;
+    private Ranking ranking;
+
+    @BeforeEach
+    void setUp() {
+
+
+        user = User.builder()
+                .id(1L)
+                .nickname("runner123")
+                .email("example@example.com")
+                .cash(1000L)
+                .isRankingParticipated(false)
+                .tier(null) // 배치고사 필요 상태
+                .rankingParticipationDate(null) // 처음 참가, null 값
+                .build();
+        ranking = Ranking.builder()
+                .id(1L)
+                .tier(Tier.AMATEUR)
+                .build();
+    }
+}

--- a/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingServiceTest.java
+++ b/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingServiceTest.java
@@ -130,4 +130,42 @@ class RankingServiceTest {
                 .isAfterOrEqualTo(beforeStart)
                 .isBeforeOrEqualTo(afterStart.plusSeconds(1)); // 1초 이내 차이가 나도록 설정
     }
+
+    @Test
+    @DisplayName("배치고사 통과 후 티어가 결정되고, 랭킹 방에 배정되며, 랭킹 참가 상태가 true로 변경된다")
+    void handleRankingParticipation_ShouldAssignTierAndJoinRanking() {
+
+        user.setRankingParticipationDate(LocalDateTime.now().minusDays(3));
+
+
+        List<RunningRecord> records = List.of(
+                mockRunningRecord(1500), // 25분
+                mockRunningRecord(1600), // 26분 40초
+                mockRunningRecord(1400)  // 23분 20초
+        );
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(runningRecordRepository.countByUserAndDistanceAndCreatedAtAfter(eq(user), eq(5.0), eq(user.getRankingParticipationDate())))
+                .thenReturn(3L); // 3개 이상 기록 있음
+        when(runningRecordRepository.findTop3FastestRecordsAfterParticipation(eq(user), eq(5.0), eq(user.getRankingParticipationDate()), any()))
+                .thenReturn(records); // 상위 3개 기록 반환
+        when(rankingRepository.findByTier(any(Tier.class))).thenReturn(Optional.of(ranking)); // 티어 기반 랭킹 조회
+
+        doAnswer(invocation -> {
+            User mockedUser = invocation.getArgument(0);
+            mockedUser.setRankingParticipated();
+            return null;
+        }).when(userRankingService).createUserRanking(any(User.class), any(Ranking.class));
+
+        // When
+        rankingService.handleRankingParticipation(1L);
+
+        // Then
+        assertThat(user.getTier()).isNotNull();
+        assertThat(user.getTier()).isEqualTo(Tier.determineTier(1500));
+        assertThat(user.isRankingParticipated()).isTrue();
+
+        verify(rankingRepository, times(1)).findByTier(user.getTier());
+        verify(userRankingService, times(1)).createUserRanking(user, ranking);
+    }
 }

--- a/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingServiceTest.java
+++ b/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingServiceTest.java
@@ -89,4 +89,17 @@ class RankingServiceTest {
         assertThat(user.getRankingParticipationDate()).isNotNull(); // 배치고사 시작되었는지 확인
         verify(userRepository, times(1)).findById(1L); // 사용자 조회 실행 검증
     }
+
+    @Test
+    @DisplayName("이미 랭킹에 참가한 사용자는 예외가 발생해야 한다")
+    void handleRankingParticipation_ShouldThrowException_IfUserAlreadyParticipated() {
+        // Given
+        user.setRankingParticipated();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        // When & Then
+        assertThatThrownBy(() -> rankingService.handleRankingParticipation(1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.RANKING_ALREADY_PARTICIPATED.getMessage());
+    }
 }

--- a/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingServiceTest.java
+++ b/src/test/java/com/alom/dorundorunbe/domain/ranking/service/RankingServiceTest.java
@@ -102,4 +102,32 @@ class RankingServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.RANKING_ALREADY_PARTICIPATED.getMessage());
     }
+
+    @Test
+    @DisplayName("배치 상태에서 5km 기록이 3회 미만이면 예외 발생")
+    void handleRankingParticipation_ShouldThrowException_IfRecordCountIsLessThanThree() {
+        LocalDateTime beforeStart = LocalDateTime.now(); // 실행 직전 시간 저장
+        user.startRankingParticipation(); // 랭킹 참여 시작 (현재 시간으로 설정됨)
+        LocalDateTime afterStart = LocalDateTime.now();  // 실행 직후 시간 저장
+        // Given
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(runningRecordRepository.countByUserAndDistanceAndCreatedAtAfter(
+                user, 5.0, user.getRankingParticipationDate())).thenReturn(2L); // 기록 부족
+
+        // When & Then
+        assertThatThrownBy(() -> rankingService.handleRankingParticipation(1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.RANKING_MINIMUM_RECORDS_NOT_MET.getMessage());
+
+        verify(runningRecordRepository, times(1))
+                .countByUserAndDistanceAndCreatedAtAfter(user, 5.0, user.getRankingParticipationDate());
+
+
+        assertThat(user.getRankingParticipationDate()).isNotNull();
+
+
+        assertThat(user.getRankingParticipationDate())
+                .isAfterOrEqualTo(beforeStart)
+                .isBeforeOrEqualTo(afterStart.plusSeconds(1)); // 1초 이내 차이가 나도록 설정
+    }
 }

--- a/src/test/java/com/alom/dorundorunbe/domain/ranking/service/UserRankingServiceTest.java
+++ b/src/test/java/com/alom/dorundorunbe/domain/ranking/service/UserRankingServiceTest.java
@@ -164,4 +164,38 @@ class UserRankingServiceTest {
                 .convertAndSend(eq("/sub/ranking/" + amateurRanking.getId()), any(RankingResponseDto.class));
     }
 
+    @Test
+    @DisplayName("기존 2개의 포인트에서 3번째 포인트가 추가될 때 등수 업데이트 발생")
+    void updateUserRankingPointAndNotify_ShouldUpdate_WhenThirdPointIsAdded() {
+        // Given
+        User user = User.builder()
+                .id(99L)
+                .nickname("TestUser")
+                .tier(Tier.AMATEUR)
+                .build();
+
+        UserRanking userRanking = UserRanking.create(user);
+        userRanking.confirmRanking(amateurRanking);
+
+
+        userRanking.addPoint(15.0);
+        userRanking.addPoint(20.0);
+
+        when(userRankingRepository.findByUserId(user.getId())).thenReturn(Optional.of(userRanking));
+        when(userRankingRepository.findByRankingId(any())).thenReturn(List.of(userRanking));
+
+
+        userRankingService.updateUserRankingPointAndNotify(user.getId(), 18.0);
+
+
+        assertThat(userRanking.getAveragePoint()).isNotNull();
+
+
+        verify(userRankingRepository, atLeastOnce()).findByRankingId(any());
+
+
+        verify(messagingTemplate, atLeastOnce())
+                .convertAndSend(eq("/sub/ranking/" + amateurRanking.getId()), any(RankingResponseDto.class));
+    }
+
 }

--- a/src/test/java/com/alom/dorundorunbe/domain/ranking/service/UserRankingServiceTest.java
+++ b/src/test/java/com/alom/dorundorunbe/domain/ranking/service/UserRankingServiceTest.java
@@ -116,4 +116,52 @@ class UserRankingServiceTest {
 
     }
 
+    @Test
+    @DisplayName("사용자 포인트 변경 후 등수 업데이트 및 웹소켓 전송 확인")
+    void updateUserRankingPointAndNotify_ShouldUpdateRankingAndSendWebSocketMessage() {
+
+        userRankingService.updateGrades(amateurRanking.getId());
+
+        UserRanking testUserRanking = userRankings.stream()
+                .filter(ur -> ur.getUser().equals(testUser))
+                .findFirst()
+                .orElseThrow();
+
+        Long initialRank = testUserRanking.getGrade();
+
+        assertThat(initialRank).isNotNull();
+
+
+        double newPoint = 30.0;
+        testUserRanking.addPoint(newPoint);
+        testUserRanking.updateAveragePoint();
+
+
+        when(userRankingRepository.findByRankingId(amateurRanking.getId())).thenReturn(userRankings);
+        when(userRankingRepository.findByUserId(testUser.getId())).thenReturn(Optional.of(testUserRanking));
+
+
+        userRankingService.updateUserRankingPointAndNotify(testUser.getId(), newPoint);
+
+
+        userRankingService.updateGrades(amateurRanking.getId());
+
+
+        List<UserRanking> updatedRankings = userRankingRepository.findByRankingId(amateurRanking.getId());
+        UserRanking updatedUserRanking = updatedRankings.stream()
+                .filter(ur -> ur.getUser().equals(testUser))
+                .findFirst()
+                .orElseThrow();
+
+        Long updatedRank = updatedUserRanking.getGrade();
+
+
+        assertThat(updatedRank).isNotNull();
+        assertThat(updatedRank).isLessThan(initialRank);
+
+
+        verify(messagingTemplate, times(1))
+                .convertAndSend(eq("/sub/ranking/" + amateurRanking.getId()), any(RankingResponseDto.class));
+    }
+
 }

--- a/src/test/java/com/alom/dorundorunbe/domain/ranking/service/UserRankingServiceTest.java
+++ b/src/test/java/com/alom/dorundorunbe/domain/ranking/service/UserRankingServiceTest.java
@@ -198,4 +198,37 @@ class UserRankingServiceTest {
                 .convertAndSend(eq("/sub/ranking/" + amateurRanking.getId()), any(RankingResponseDto.class));
     }
 
+    @Test
+    @DisplayName("기존 3개 포인트보다 낮은 4번째 포인트 추가 시 업데이트 없이 리턴")
+    void testNoUpdateWhenLowerFourthPointAdded() {
+        // Given (테스트 데이터 준비)
+        User user = User.builder()
+                .id(99L)
+                .nickname("TestUser")
+                .tier(Tier.AMATEUR)
+                .build();
+
+        UserRanking userRanking = UserRanking.create(user);
+        userRanking.confirmRanking(amateurRanking);
+
+
+        userRanking.addPoint(100.0);
+        userRanking.addPoint(90.0);
+        userRanking.addPoint(80.0);
+        Double originalAvgPoint = userRanking.updateAveragePoint();
+        Long userId = user.getId();
+
+
+        when(userRankingRepository.findByUserId(userId)).thenReturn(Optional.of(userRanking));
+
+
+        userRankingService.updateUserRankingPointAndNotify(userId, 60.0);
+
+
+        assertThat(userRanking.getAveragePoint()).isEqualTo(originalAvgPoint); // 평균 값이 그대로여야 함
+
+        // updateGrades()가 호출되지 않아야 함
+        verify(userRankingRepository, never()).findByRankingId(anyLong());
+    }
+
 }

--- a/src/test/java/com/alom/dorundorunbe/domain/ranking/service/UserRankingServiceTest.java
+++ b/src/test/java/com/alom/dorundorunbe/domain/ranking/service/UserRankingServiceTest.java
@@ -1,0 +1,75 @@
+package com.alom.dorundorunbe.domain.ranking.service;
+
+import com.alom.dorundorunbe.domain.ranking.domain.*;
+import com.alom.dorundorunbe.domain.ranking.dto.RankingResponseDto;
+import com.alom.dorundorunbe.domain.ranking.repository.UserRankingRepository;
+import com.alom.dorundorunbe.domain.user.domain.User;
+import com.alom.dorundorunbe.global.enums.Tier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserRankingServiceTest {
+
+    @Mock
+    private UserRankingRepository userRankingRepository;
+
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks
+    private UserRankingService userRankingService;
+
+    private Ranking amateurRanking;
+    private List<UserRanking> userRankings = new ArrayList<>();
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        amateurRanking = Ranking.create(Tier.AMATEUR);
+
+        //  10명의 유저 생성
+        for (int i = 1; i <= 10; i++) {
+            User user = User.builder()
+                    .id((long) i)
+                    .nickname("User" + i)
+                    .tier(Tier.AMATEUR)
+                    .build();
+
+            UserRanking userRanking = UserRanking.create(user);
+            userRanking.confirmRanking(amateurRanking);
+
+
+            // 각 사용자에게 3개의 포인트 추가
+            userRanking.addPoint(10.0 + i);
+            userRanking.addPoint(12.0 + i);
+            userRanking.addPoint(14.0 + i);
+            userRanking.updateAveragePoint();
+
+            userRankings.add(userRanking);
+        }
+
+
+        testUser = userRankings.get(4).getUser();
+
+
+        when(userRankingRepository.findByRankingId(amateurRanking.getId())).thenReturn(userRankings);
+
+
+        userRankingService.updateGrades(amateurRanking.getId());
+    }
+}

--- a/src/test/java/com/alom/dorundorunbe/domain/ranking/service/UserRankingServiceTest.java
+++ b/src/test/java/com/alom/dorundorunbe/domain/ranking/service/UserRankingServiceTest.java
@@ -72,4 +72,48 @@ class UserRankingServiceTest {
 
         userRankingService.updateGrades(amateurRanking.getId());
     }
+    @Test
+    @DisplayName("사용자 포인트 변경 후 등수 업데이트")
+    void updateUserRankingPointAndNotify_ShouldUpdateRankingWhenUserPointChanges() {
+        //기존 등수 확인
+        userRankingService.updateGrades(amateurRanking.getId());
+
+        UserRanking testUserRanking = userRankings.stream()
+                .filter(ur -> ur.getUser().equals(testUser))
+                .findFirst()
+                .orElseThrow();
+
+        Long initialRank = testUserRanking.getGrade();
+
+
+        //기존 등수가 null이면 테스트 중단
+        assertThat(initialRank).isNotNull();
+
+        //User5의 포인트를 대폭 증가시켜 1등 만듦
+        double newPoint = 30.0;
+        testUserRanking.addPoint(newPoint);
+        testUserRanking.updateAveragePoint();
+
+
+        when(userRankingRepository.findByRankingId(amateurRanking.getId())).thenReturn(userRankings);
+
+
+        userRankingService.updateGrades(amateurRanking.getId());
+
+
+        List<UserRanking> updatedRankings = userRankingRepository.findByRankingId(amateurRanking.getId());
+        UserRanking updatedUserRanking = updatedRankings.stream()
+                .filter(ur -> ur.getUser().equals(testUser))
+                .findFirst()
+                .orElseThrow();
+
+        Long updatedRank = updatedUserRanking.getGrade();
+
+
+        //등수가 올라갔는지 확인
+        assertThat(updatedRank).isNotNull();
+        assertThat(updatedRank).isEqualTo(1); //1등
+
+    }
+
 }

--- a/src/test/java/com/alom/dorundorunbe/domain/ranking/service/UserRankingServiceTest.java
+++ b/src/test/java/com/alom/dorundorunbe/domain/ranking/service/UserRankingServiceTest.java
@@ -231,4 +231,40 @@ class UserRankingServiceTest {
         verify(userRankingRepository, never()).findByRankingId(anyLong());
     }
 
+    @Test
+    @DisplayName("포인트가 1개에서 2개가 될 경우, 평균 점수가 업데이트되지만 3개가 아니므로 updateGrades()는 호출되지 않음")
+    void testAddingSecondPointDoesNotTriggerGradeUpdate() {
+
+        User user = User.builder()
+                .id(100L)
+                .nickname("TestUser")
+                .tier(Tier.AMATEUR)
+                .build();
+
+        UserRanking userRanking = UserRanking.create(user);
+        userRanking.confirmRanking(amateurRanking);
+
+
+        userRanking.addPoint(90.0);
+        Long userId = user.getId();
+
+
+        when(userRankingRepository.findByUserId(userId)).thenReturn(Optional.of(userRanking));
+
+
+        userRankingService.updateUserRankingPointAndNotify(userId, 80.0);
+
+        // Then
+        // 포인트 개수가 2개로 늘어났는지 확인
+        assertThat(userRanking.getPoints().size()).isEqualTo(2);
+
+        // 평균 점수가 null 유지
+        assertThat(userRanking.getAveragePoint()).isNull();
+
+
+        // updateGrades()가 호출되지 않았는지 확인
+        verify(userRankingRepository, never()).findByRankingId(anyLong());
+    }
+
+
 }


### PR DESCRIPTION
## ❓ 기능 추가 배경

< 여기에 기능 추가 배경 >

## ➕ 추가/변경된 기능

랭킹 침가 시 배치고사/ 올바른 랭킹 방 참가
랭킹 보상 지급 및 UserRanking 삭제, resetRankingParticipated() 여부 확인
point 계산 로직(일주일 중 가장 잘한 3가지로 등수 실시간 업데이트)
3개 미만 point를 가진 사용자 등수 계산 제외(grade null처리)

## 🗎 관련 이슈

#35 
